### PR TITLE
Added automake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,7 @@ RUN \
 # ---- Automake toolchain ----
 FROM dependencies AS automake_tools
 RUN \
+  export DEBIAN_FRONTEND=noninteractive && \
   apt -y install autoconf automake libtool pkg-config
 
 # ---- Build AGT tools ----

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,16 +61,20 @@ RUN \
   apt -y install software-properties-common && \
   add-apt-repository ppa:vriviere/ppa && \
   apt -y update && \
-  apt -y install cross-mint-essential cflib-m68k-atari-mint gemma-m68k-atari-mint ldg-m68k-atari-mint sdl-m68k-atari-mint ncurses-m68k-atari-mint zlib-m68k-atari-mint readline-m68k-atari-mint openssl-m68k-atari-mint
+  apt -y install cross-mint-essential cflib-m68k-atari-mint gemma-m68k-atari-mint gemlib-m68k-atari-mint ldg-m68k-atari-mint sdl-m68k-atari-mint ncurses-m68k-atari-mint zlib-m68k-atari-mint readline-m68k-atari-mint openssl-m68k-atari-mint pml-m68k-atari-mint
+
+# ---- Automake toolchain ----
+FROM dependencies AS automake_tools
+RUN \
+  apt -y install autoconf automake libtool pkg-config
 
 # ---- Build AGT tools ----
 # logronoide has prebuild binaries in his git. Just use them
-FROM dependencies AS agt
+FROM automake_tools AS agt
 WORKDIR /
 RUN \
   git clone https://bitbucket.org/logronoide/agtools.git && \
   chmod -R +x /agtools/bin/Linux
-
 
 COPY ./agt/config.sh /agtools/config.sh
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Whether you're an experienced Atari ST developer or new to the platform, this im
 
 - [`Python`]() in case you want to write helper scripts to automate your development process.
 
+- [`autoconf`, `automake`, `libtool`, `pkg-config`]() for projects that use the GNU autotools build system.
+
 These tools are all included in the docker image and are ready to use out of the box, making it easy for you to get started writing code for the Atari ST. Hopefully, I will be expanding the range of tools and resources available to developers who use the image in the future. By adding more tools, a more comprehensive and complete development environment for developers who are interested in writing code for the Atari ST will come. 
 
 

--- a/install/install_atarist_toolkit_docker.cmd
+++ b/install/install_atarist_toolkit_docker.cmd
@@ -38,7 +38,7 @@ echo Installing the command stcmd in %TARGET%...
 > "%TARGET%" (
     echo @echo off
     echo setlocal
-    echo if "%%DOCKER_ACCOUNT%%"=="" set "DOCKER_ACCOUNT=logronoide"
+    echo if "%%DOCKER_ACCOUNT%%"=="" set "DOCKER_ACCOUNT=%DOCKER_ACCOUNT%"
     echo if "%%STCMD_IMAGE_TAG%%"=="" set "STCMD_IMAGE_TAG=latest"
     echo if "%%ST_WORKING_FOLDER%%"=="" ^(
     echo     set "ST_WORKING_FOLDER=%%cd%%"

--- a/install/install_atarist_toolkit_docker.cmd
+++ b/install/install_atarist_toolkit_docker.cmd
@@ -39,7 +39,7 @@ echo Installing the command stcmd in %TARGET%...
     echo @echo off
     echo setlocal
     echo if "%%DOCKER_ACCOUNT%%"=="" set "DOCKER_ACCOUNT=%DOCKER_ACCOUNT%"
-    echo if "%%STCMD_IMAGE_TAG%%"=="" set "STCMD_IMAGE_TAG=latest"
+    echo if "%%STCMD_IMAGE_TAG%%"=="" set "STCMD_IMAGE_TAG=%STCMD_IMAGE_TAG%"
     echo if "%%ST_WORKING_FOLDER%%"=="" ^(
     echo     set "ST_WORKING_FOLDER=%%cd%%"
     echo     if not "%%STCMD_QUIET%%"=="1" echo ST_WORKING_FOLDER is empty: using %%cd%% as absolute path to source code working folder.

--- a/install/install_atarist_toolkit_docker.sh
+++ b/install/install_atarist_toolkit_docker.sh
@@ -31,7 +31,7 @@ echo "Installing the command stcmd in /usr/local/bin. Please enter your root pas
 cat << EOF > /usr/local/bin/stcmd
 #!/bin/bash
 if [ -z "\${DOCKER_ACCOUNT}" ]; then
-    DOCKER_ACCOUNT=${DOCKER_ACCOUNT}
+    DOCKER_ACCOUNT="${DOCKER_ACCOUNT}"
 fi
 if [ -z "\${STCMD_IMAGE_TAG}" ]; then
     STCMD_IMAGE_TAG="${STCMD_IMAGE_TAG}"

--- a/install/install_atarist_toolkit_docker.sh
+++ b/install/install_atarist_toolkit_docker.sh
@@ -31,7 +31,7 @@ echo "Installing the command stcmd in /usr/local/bin. Please enter your root pas
 cat << EOF > /usr/local/bin/stcmd
 #!/bin/bash
 if [ -z "\${DOCKER_ACCOUNT}" ]; then
-    DOCKER_ACCOUNT=logronoide
+    DOCKER_ACCOUNT=${DOCKER_ACCOUNT}
 fi
 if [ -z "\${STCMD_IMAGE_TAG}" ]; then
     STCMD_IMAGE_TAG="latest"

--- a/install/install_atarist_toolkit_docker.sh
+++ b/install/install_atarist_toolkit_docker.sh
@@ -34,7 +34,7 @@ if [ -z "\${DOCKER_ACCOUNT}" ]; then
     DOCKER_ACCOUNT=${DOCKER_ACCOUNT}
 fi
 if [ -z "\${STCMD_IMAGE_TAG}" ]; then
-    STCMD_IMAGE_TAG="latest"
+    STCMD_IMAGE_TAG="${STCMD_IMAGE_TAG}"
 fi
 if [ -z "\${ST_WORKING_FOLDER}" ]; then
     ST_WORKING_FOLDER=\$(pwd)


### PR DESCRIPTION
I've come across a number of different multi-platform projects recently that require `automake` to generate an Atari ST `Makefile`, like Doom8088 and SDL 1.2, so thought it would be useful to add it.

I've also tweaked the installer scripts to carry forward the `DOCKER_ACCOUNT` and `STCMD_IMAGE_TAG` used at install time as the defaults for `stcmd` to ensure that the version you installed is the default version that's actually used.